### PR TITLE
Fix incorrect Make command

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -239,7 +239,7 @@ It exposes a couple of targets:
    exist yet.
 * `make update-devkit` - updates `adminrouter-devkit`. Should be run every time
    the Dockerfile or its dependencies change.
-* `make tests` - launch all the tests. Worth noting is the fact that McCabe
+* `make test` - launch all the tests. Worth noting is the fact that McCabe
    complexity of the code is also verified, and an error is raised if it's
    equal to or above 10.
 * `make shell` - launch an interactive shell within the devkit container. Should


### PR DESCRIPTION
## High Level Description

This fixes an incorrect command in the Admin Router README.
The tests would not run with the old command, and they will run with the new command.

## Related Issues

  - [DCOS_OSS-919](https://jira.dcos.io/browse/DCOS_OSS-919) Admin Router docs say to run "make tests", should be "make test"

## Checklist for all PR's

  - [ X ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a documentation-only change.
  - [ X ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ X ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)